### PR TITLE
[반재영] 로그인 인증 오류 수정

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,8 @@ import 'mapbox-gl/dist/mapbox-gl.css';
 
 import { Outlet } from "react-router-dom";
 
-import AuthProvider from "./contexts/AuthContext";
+import AuthProvider from "./contexts/AuthProvider";
+import PhaseContextProvider from "./contexts/PhaseContext";
 import { useScrollReset } from "./hooks/useScrollReset";
 
 function App() {
@@ -11,7 +12,9 @@ function App() {
   return (
     <>
       <AuthProvider>
-        <Outlet />
+        <PhaseContextProvider>
+          <Outlet />
+        </PhaseContextProvider>
       </AuthProvider>
     </>
   );

--- a/frontend/src/api/dropdownApi.ts
+++ b/frontend/src/api/dropdownApi.ts
@@ -53,8 +53,12 @@ export const fetchOperationsByRobot = async (robotId: string) => {
           robotId,
         )}&operation=${encodeURIComponent(operation._id)}&fields=timestamp`;
 
-        const telemetriesResponse = await fetch(telemetriesUrl);
+        const telemetriesResponse = await fetch(telemetriesUrl, {headers});
         if (!telemetriesResponse.ok) {
+          if (operationsResponse.status === 401) {
+            // 로그인 토큰이 유효하지 않음
+            throw new Error("Unauthorized user");
+          }
           throw new Error(
             `Failed to fetch telemetries: ${telemetriesResponse.statusText}`,
           );

--- a/frontend/src/api/dropdownApi.ts
+++ b/frontend/src/api/dropdownApi.ts
@@ -55,7 +55,7 @@ export const fetchOperationsByRobot = async (robotId: string) => {
 
         const telemetriesResponse = await fetch(telemetriesUrl, {headers});
         if (!telemetriesResponse.ok) {
-          if (operationsResponse.status === 401) {
+          if (telemetriesResponse.status === 401) {
             // 로그인 토큰이 유효하지 않음
             throw new Error("Unauthorized user");
           }

--- a/frontend/src/components/home/DataList.tsx
+++ b/frontend/src/components/home/DataList.tsx
@@ -29,10 +29,9 @@ const DroneList = () => {
           (
             drone: { robot_id: string; name: string; img: string; _id: string },
             op: { robot: string },
-            index: number,
           ) => (
             <FlightDataCard
-              key={index}
+              key={drone._id}
               name={drone.name}
               img={drone.img}
               robot_id={drone.robot_id}

--- a/frontend/src/components/home/LoginForm.tsx
+++ b/frontend/src/components/home/LoginForm.tsx
@@ -23,7 +23,9 @@ export const LoginForm = ({onSuccess}: { onSuccess: () => void;}) => {
       onSuccess: (data) => {
         setIsAuth(true);
         localStorage.setItem("token", data);
-        alert("Welcome aboard!");
+        setTimeout(()=> {
+          alert("Welcome aboard!");
+        },0)
         navigate("/");
         onSuccess();
       },

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, Dispatch, ReactNode, SetStateAction, useEffect, useState } from "react";
+import { createContext, Dispatch, SetStateAction } from "react";
 
 interface AuthContextProp{
   isAuth: boolean|null;
@@ -11,16 +11,3 @@ export const AuthContext = createContext<AuthContextProp>({
 });
 
 
-interface AuthProviderProp {
-  children: ReactNode;
-}
-export default function AuthProvider({ children }: AuthProviderProp) {
-  const [isAuth, setIsAuth] = useState<boolean | null>(null);
-
-  useEffect(() => {
-    const token = localStorage.getItem("token");
-    setIsAuth(!!token);
-  }, []);
-
-  return <AuthContext.Provider value={{ isAuth, setIsAuth }}>{children}</AuthContext.Provider>;
-}

--- a/frontend/src/contexts/AuthProvider.tsx
+++ b/frontend/src/contexts/AuthProvider.tsx
@@ -1,0 +1,27 @@
+import { ReactNode, useEffect,useState } from "react";
+
+import { AuthContext } from "./AuthContext";
+
+interface AuthProviderProp {
+  children: ReactNode;
+}
+export default function AuthProvider({ children }: AuthProviderProp) {
+  const [isAuth, setIsAuth] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const checkToken = () => {
+      const token = localStorage.getItem("token");
+      setIsAuth(!!token);
+    };
+
+    checkToken();
+    window.addEventListener("storage", checkToken);
+    return () => window.removeEventListener("storage", checkToken);
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ isAuth, setIsAuth }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/frontend/src/routes/pages/ChartPage.tsx
+++ b/frontend/src/routes/pages/ChartPage.tsx
@@ -34,6 +34,7 @@ const ChartPage: React.FC = () => {
   const navigate = useNavigate();
   
   useEffect(()=>{
+    if(isAuth === null) return;
     if(!isAuth){
       alert("Signing in is required");
       navigate("/");

--- a/frontend/src/routes/pages/HomePage.tsx
+++ b/frontend/src/routes/pages/HomePage.tsx
@@ -63,11 +63,54 @@ export function HomePage() {
 
       {/* Main Content */}
       <HeroSection />
-      <div ref={dataListRef}>
-        <DroneList />
-      </div>
-      {/* TODO: 로그인 안했을 경우의 화면 */}
-      {!isAuth && <div></div>}
+      {isAuth ? (
+        <div ref={dataListRef}>
+          <DroneList />
+        </div>
+      ) : (
+        <div className="mx-auto mb-10 flex h-[1024px] flex-col items-center justify-center text-center">
+          <p className="title" id="DataList">
+            Select the Drone
+          </p>
+          <p className="subtitle mt-2">
+            Select a drone and view its data visualization.
+          </p>
+          <div className="relative mt-10 flex h-auto min-h-[37.5rem] w-[75rem] items-center justify-center">
+            <div className="mx-auto relative h-[300px] w-[300px] rounded border-2 border-[#B2B7B7] bg-white py-16">
+              <div>
+                <img
+                  className="absolute left-9 top-10 transition-all duration-300 ease-in-out group-hover:left-4 group-hover:top-5 group-active:left-4 group-active:top-5"
+                  src="/images/card-left-up.svg"
+                  alt="카드 좌상 상세 디자인"
+                />
+                <img
+                  className="absolute right-9 top-10 transition-all duration-300 ease-in-out group-hover:right-4 group-hover:top-5 group-active:right-4 group-active:top-5"
+                  src="/images/card-right-up.svg"
+                  alt="카드 우상 상세 디자인"
+                />
+                <img
+                  className="absolute bottom-10 left-9 transition-all duration-300 ease-in-out group-hover:bottom-5 group-hover:left-4 group-active:bottom-5 group-active:left-4"
+                  src="/images/card-left-down.svg"
+                  alt="카드 좌하 상세 디자인"
+                />
+                <img
+                  className="absolute bottom-10 right-9 transition-all duration-300 ease-in-out group-hover:bottom-5 group-hover:right-4 group-active:bottom-5 group-active:right-4"
+                  src="/images/card-right-down.svg"
+                  alt="카드 우하 상세 디자인"
+                />
+              </div>
+              <div className="mx-auto flex h-[100px] w-[200px] items-center justify-center blur-sm">
+                <img src="/images/drone-01.svg" alt="드론" />
+              </div>
+            </div>
+            <div className="absolute h-[300px] w-full text-4xl">
+              <div className="flex h-full items-center justify-center font-light italic text-click">
+                Please sign in to view the drone data.
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/routes/pages/Map3dPage.tsx
+++ b/frontend/src/routes/pages/Map3dPage.tsx
@@ -28,8 +28,8 @@ export default function Map3dPage() {
   const navigate = useNavigate();
 
   useEffect(()=>{
-    const token = localStorage.getItem("token")
-    if(!token){
+    if(isAuth === null) return;
+    if(!isAuth){
       alert("Signing in is required");
       navigate("/");
     }

--- a/frontend/src/routes/pages/Map3dPage.tsx
+++ b/frontend/src/routes/pages/Map3dPage.tsx
@@ -28,9 +28,10 @@ export default function Map3dPage() {
   const navigate = useNavigate();
 
   useEffect(()=>{
-    if(!isAuth){
+    const token = localStorage.getItem("token")
+    if(!token){
       alert("Signing in is required");
-      navigate("/")
+      navigate("/");
     }
   },[isAuth, navigate])
 
@@ -48,7 +49,7 @@ export default function Map3dPage() {
     enabled: !!selectedOperationAndDate,
   });
 
-  if (isPending) return "Loading...";
+  // if (isPending) return "Loading...";
   if (error) {
     if (error.message === "Unauthorized user") {
       localStorage.removeItem("token");

--- a/frontend/src/routes/pages/MapPage.tsx
+++ b/frontend/src/routes/pages/MapPage.tsx
@@ -29,7 +29,8 @@ export default function MapPage() {
 
 
   useEffect(()=>{
-    if(!isAuth){
+    const token = localStorage.getItem("token")
+    if(!token){
       alert("Signing in is required");
       navigate("/");
     }
@@ -49,7 +50,7 @@ export default function MapPage() {
     enabled: !!selectedOperationAndDate,
   });
 
-  if (isPending) return "Loading...";
+  // if (isPending) return "Loading...";
   if (error) {
     if (error.message === "Unauthorized user") {
       localStorage.removeItem("token");

--- a/frontend/src/routes/pages/MapPage.tsx
+++ b/frontend/src/routes/pages/MapPage.tsx
@@ -29,8 +29,8 @@ export default function MapPage() {
 
 
   useEffect(()=>{
-    const token = localStorage.getItem("token")
-    if(!token){
+    if(isAuth === null) return;
+    if(!isAuth){
       alert("Signing in is required");
       navigate("/");
     }

--- a/frontend/src/types/latLonAlt.ts
+++ b/frontend/src/types/latLonAlt.ts
@@ -2,7 +2,7 @@ export interface LatLonAlt {
   lat: number; //위도
   lon: number; //경도
   alt: number; //고도
-  heading: number | null;
+  // heading: number | null;
 }
 export interface LatLon {
   lat: number; //위도


### PR DESCRIPTION
## 로그인 인증여부 오류
오류 상황
- 차트/지도 페이지에 주소로 접근시 로그인 인증이 안되어서 접근 불가
- 서비스 로직대로 이동하면 접근이 가능하나 접근 이후 새로고침하면 접근 불가

원인
- 로그인 인증여부를 처리하는 `isAuthContext`의 초기값이 `null`로 되어있어서, 토큰을 읽어오기전에 `isAuth`가 `null`로 판단됨. 
- `useContext`는 메모리에 저장되어서 새로고침시 상태가 초기화됨(상태를 다시 판단하는 중에 null로 판단됨)

해결
- useEffect에 isAuth가 null 인 경우 추가 `if(isAuth === null) return`

## 기타
1. 변수명 잘못 지정한 것 수정(`operationsResponse` -> `telemetriesResponse`)
2. 로그인 전 데이터리스트 화면 추가
3. `AuthContext`와 `AuthProvider` 파일분리(Fast refresh) 