### PR TITLE
[반재영] 지도 오류 수정, 드론 기본 회전값 지정, 레이아웃 수정

### DIFF
--- a/frontend/src/components/charts/DetailedDataHeader.tsx
+++ b/frontend/src/components/charts/DetailedDataHeader.tsx
@@ -38,7 +38,7 @@ const DetailedDataHeader: React.FC<Props> = ({
       </Button>
       <article className="min-w-[226px] md:w-2/3">
         <h1 className="text-2xl font-semibold md:text-3xl">Detailed Data</h1>
-        <span className="hidden text-xs md:block md:text-sm">
+        <span className="hidden text-xs lg:block md:text-sm">
           Visualize drone data with interactive charts and maps. <br />
           Explore trends and movement patterns for the selected date.
         </span>

--- a/frontend/src/components/charts/DropdownSection.tsx
+++ b/frontend/src/components/charts/DropdownSection.tsx
@@ -123,7 +123,7 @@ const DropdownSection: React.FC<DropdownSectionProps> = ({
   return (
     <div
       className={twMerge(
-        `mx-3 flex flex-wrap justify-center gap-3 md:flex-nowrap md:justify-end ${className}`,
+        `mx-3 flex flex-wrap justify-center gap-3 lg:flex-nowrap md:justify-end ${className}`,
       )}
     >
       {!isRobotsLoading && (

--- a/frontend/src/components/map/Map2D.tsx
+++ b/frontend/src/components/map/Map2D.tsx
@@ -14,17 +14,9 @@ import ProgressBarBtns from "./ProgressBarBtns";
 
 interface Props {
   positionData: FormattedTelemetryPositionData[] | null;
-  stateData:
-    | {
-        timestamp: Date;
-        payload: {
-          text: string;
-        };
-      }[]
-    | null;
 }
 
-export default function Map2D({ positionData, stateData }: Props) {
+export default function Map2D({ positionData }: Props) {
   const mapRef = useRef<MapRef>(null); // 맵 인스턴스 접근
   const markerRef = useRef<mapboxgl.Marker | null>(null);
   const [mapLoaded, setMapLoaded] = useState(false);
@@ -323,7 +315,6 @@ export default function Map2D({ positionData, stateData }: Props) {
         <ProgressBar
           startTime={startEndTime.startTime}
           endTime={startEndTime.endTime}
-          stateData={stateData}
         >
           <PlayHead
             duration={totalDuration}

--- a/frontend/src/components/map/ProgressBar.tsx
+++ b/frontend/src/components/map/ProgressBar.tsx
@@ -1,32 +1,13 @@
-import { ReactNode, useContext } from "react";
+import { ReactNode } from "react";
 
-import { PhaseContext } from "@/contexts/PhaseContext";
 
 interface ProgressProps {
   children: ReactNode;
   startTime: string;
   endTime: string;
-  stateData: {
-    timestamp: Date;
-    payload: {
-      text: string;
-    };
-  }[] | null;
 }
 
-const ProgressBar = ({ children, startTime, endTime, stateData }: ProgressProps) => {
-  const { phase } = useContext(PhaseContext);
-
-  // 상태 메시지 타임라인 정렬
-  const sortedStates = stateData
-    ? [...stateData].sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime())
-    : [];
-
-  // 현재 phase에 맞는 상태 메시지 찾기
-  const currentIndex = Math.floor(phase * (sortedStates.length - 1));
-  const currentState = sortedStates[currentIndex] || null;
-  console.log(currentState)
-
+const ProgressBar = ({ children, startTime, endTime }: ProgressProps) => {
 
   return (
     <div className="video-container mx-auto flex w-[80%] max-w-[800px]">

--- a/frontend/src/components/map3d/AttitudeWidget.tsx
+++ b/frontend/src/components/map3d/AttitudeWidget.tsx
@@ -70,9 +70,9 @@ const AttitudeWidget = ({
   const currentYawInDegrees = radToDeg(currentYaw);
 
   return (
-    <div className="toolbar-attitude mx-6 my-0 hidden h-[27vh] w-[20vw] grid-cols-[1fr_1fr] grid-rows-[33%_1fr] rounded-[10px] bg-white bg-opacity-60 md:block">
+    <div className="toolbar-attitude mx-6 my-0 hidden h-[27vh] w-[30vw] max-w-[17rem] sm:flex sm:flex-col rounded-[10px] bg-white bg-opacity-60 md:block">
       {/* 배터리 및 헤딩을 가로로 정렬 */}
-      <div className="col-start-1 row-start-1 flex w-full items-start justify-between p-2">
+      <div className="flex w-full h-5 items-start justify-between p-2">
         {/* 배터리 */}
         <div className="battery flex items-center">
           <img
@@ -87,19 +87,19 @@ const AttitudeWidget = ({
 
         {/* 헤딩 */}
         <div className="flex items-start">
-          <div className="angle mr-2 inline-block w-[35px] rounded-[30px] border-2 border-black text-center text-[12px]">
+          <div className="angle mr-2 inline-block w-[35px] rounded-[30px] border-[1px] border-black text-center text-[12px]">
             {currentHeading}°
           </div>
           <br />
-          <div>
+          {/* <div>
             <img src="/images/Frame 69.svg" alt="Heading" />
-          </div>
+          </div> */}
         </div>
       </div>
 
       {/* 드론 3D 모델 */}
-      <div className="attitude-3d relative col-span-2 row-start-2 flex items-center justify-center p-2">
-        <div className="flex h-[10vh] w-[20vw] items-center justify-center">
+      <div className="attitude-3d relative flex items-center justify-center p-2 w-full h-full">
+        <div className="flex h-full w-full items-center justify-center">
           <Suspense fallback={<div>Loading drone...</div>}>
             <Drone
               scale={100}
@@ -109,8 +109,8 @@ const AttitudeWidget = ({
                 currentPitchInDegrees,
               ]} // 도 단위로 변환된 값 사용
               yAnimationHeight={0}
-              height={"30vh"}
-              width={"20vw"}
+              height={"100%"}
+              width={"100%"}
             />
           </Suspense>
         </div>

--- a/frontend/src/components/map3d/CesiumViewer3D.tsx
+++ b/frontend/src/components/map3d/CesiumViewer3D.tsx
@@ -1,5 +1,6 @@
 import * as Cesium from "cesium";
 import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
+import { degToRad } from "three/src/math/MathUtils";
 
 import { PhaseContext } from "@/contexts/PhaseContext";
 import { FormattedTelemetryPositionData } from "@/types/telemetryPositionDataTypes";
@@ -9,6 +10,7 @@ import PlayHead from "../map/PlayHead";
 import ProgressBar from "../map/ProgressBar";
 import ProgressBarBtns from "../map/ProgressBarBtns";
 
+const adjustDroneHeading = degToRad(216);
 interface CesiumViewerProps {
   positionData: FormattedTelemetryPositionData[] | null;
 }
@@ -36,7 +38,6 @@ const CesiumViewer: React.FC<CesiumViewerProps> = ({
     endTime: string;
   }>({ startTime: "", endTime: "" });
   const [flightStartTime, setFlightStartTime] = useState(0);
-
   const { phase, setPhase } = useContext(PhaseContext);
 
   // Cesium viewer 초기화
@@ -99,13 +100,13 @@ const CesiumViewer: React.FC<CesiumViewerProps> = ({
           prevPosition,
           new Cesium.Cartesian3(),
         );
-
+        
         if (Cesium.Cartesian3.magnitudeSquared(direction) > 0) {
           Cesium.Cartesian3.normalize(direction, direction);
           const heading = Math.atan2(direction.y, direction.x);
           const orientation = Cesium.Transforms.headingPitchRollQuaternion(
             position,
-            new Cesium.HeadingPitchRoll(heading, 0, 0),
+            new Cesium.HeadingPitchRoll(heading+adjustDroneHeading, 0, 0),
           );
           modelEntityRef.current.orientation = new Cesium.ConstantProperty(
             orientation,

--- a/frontend/src/components/map3d/CesiumViewer3D.tsx
+++ b/frontend/src/components/map3d/CesiumViewer3D.tsx
@@ -11,17 +11,10 @@ import ProgressBarBtns from "../map/ProgressBarBtns";
 
 interface CesiumViewerProps {
   positionData: FormattedTelemetryPositionData[] | null;
-  stateData:
-    | {
-        timestamp: Date;
-        payload: { text: string };
-      }[]
-    | null;
 }
 
 const CesiumViewer: React.FC<CesiumViewerProps> = ({
   positionData,
-  stateData,
 }) => {
   const cesiumContainerRef = useRef<HTMLDivElement | null>(null);
   const viewerRef = useRef<Cesium.Viewer | null>(null);
@@ -318,7 +311,6 @@ const CesiumViewer: React.FC<CesiumViewerProps> = ({
         <ProgressBar
           startTime={startEndTime.startTime}
           endTime={startEndTime.endTime}
-          stateData={stateData}
         >
           <PlayHead
             duration={totalDuration}

--- a/frontend/src/components/map3d/CesiumViewer3D.tsx
+++ b/frontend/src/components/map3d/CesiumViewer3D.tsx
@@ -1,5 +1,5 @@
 import * as Cesium from "cesium";
-import { useCallback, useContext, useEffect, useRef, useState } from "react";
+import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
 
 import { PhaseContext } from "@/contexts/PhaseContext";
 import { FormattedTelemetryPositionData } from "@/types/telemetryPositionDataTypes";
@@ -43,48 +43,7 @@ const CesiumViewer: React.FC<CesiumViewerProps> = ({
   useEffect(() => {
     if (!cesiumContainerRef.current || isInitialized) return;
 
-    const initViewer = async () => {
-      try {
-        Cesium.Ion.defaultAccessToken = import.meta.env.VITE_CESIUM_ION_API_KEY;
-        const terrainProvider = await Cesium.createWorldTerrainAsync();
-
-        if (viewerRef.current) {
-          viewerRef.current.destroy();
-        }
-        if (!cesiumContainerRef.current) return;
-        viewerRef.current = new Cesium.Viewer(cesiumContainerRef.current, {
-          terrainProvider,
-          animation: false,
-          timeline: false,
-          homeButton: false,
-          sceneModePicker: false,
-          selectionIndicator: false,
-          navigationHelpButton: false,
-          fullscreenButton: false,
-          geocoder: false,
-          infoBox: false,
-          navigationInstructionsInitiallyVisible: false,
-          baseLayerPicker: false,
-          vrButton: false,
-          projectionPicker: false,
-        });
-
-        const buildingTileset = await Cesium.Cesium3DTileset.fromIonAssetId(
-          96188,
-          {
-            maximumScreenSpaceError: 16,
-          },
-        );
-
-        viewerRef.current.scene.primitives.add(buildingTileset);
-
-        setIsInitialized(true);
-      } catch (error) {
-        console.error("Failed to initialize Cesium:", error);
-      }
-    };
-
-    initViewer();
+    initViewer(viewerRef, cesiumContainerRef, setIsInitialized);
 
     return () => {
       if (viewerRef.current) {
@@ -331,3 +290,46 @@ const CesiumViewer: React.FC<CesiumViewerProps> = ({
 };
 
 export default CesiumViewer;
+
+
+const initViewer = async (
+  viewerRef: React.MutableRefObject<Cesium.Viewer | null>,
+  cesiumContainerRef: React.MutableRefObject<HTMLDivElement | null>,
+  setIsInitialized: React.Dispatch<React.SetStateAction<boolean>>,
+) => {
+  try {
+    Cesium.Ion.defaultAccessToken = import.meta.env.VITE_CESIUM_ION_API_KEY;
+    const terrainProvider = await Cesium.createWorldTerrainAsync();
+
+    if (viewerRef.current) {
+      viewerRef.current.destroy();
+    }
+    if (!cesiumContainerRef.current) return;
+    viewerRef.current = new Cesium.Viewer(cesiumContainerRef.current, {
+      terrainProvider,
+      animation: false,
+      timeline: false,
+      homeButton: false,
+      sceneModePicker: false,
+      selectionIndicator: false,
+      navigationHelpButton: false,
+      fullscreenButton: false,
+      geocoder: false,
+      infoBox: false,
+      navigationInstructionsInitiallyVisible: false,
+      baseLayerPicker: false,
+      vrButton: false,
+      projectionPicker: false,
+    });
+
+    const buildingTileset = await Cesium.Cesium3DTileset.fromIonAssetId(96188, {
+      maximumScreenSpaceError: 16,
+    });
+
+    viewerRef.current.scene.primitives.add(buildingTileset);
+
+    setIsInitialized(true);
+  } catch (error) {
+    console.error("Failed to initialize Cesium:", error);
+  }
+};

--- a/frontend/src/components/map3d/LoadingMessage.tsx
+++ b/frontend/src/components/map3d/LoadingMessage.tsx
@@ -1,6 +1,6 @@
 export default function LoadingMessage({className}: {className?:string}){
   return (
-    <div className={`fixed flex h-screen w-screen items-center justify-center ${className}`}>
+    <div className={`fixed left-1/2 -translate-x-1/2 top-1/2 -translate-y-1/2 items-center justify-center ${className}`}>
       <div className="pointer-events-none flex h-20 w-56 items-center justify-center gap-5 rounded-2xl bg-white bg-opacity-90 drop-shadow-md">
         <img src="/icons/loading.svg" alt="" className="h-6 w-6 animate-spin" />
         <p className="text-center">Loading...</p>

--- a/frontend/src/components/map3d/MiniMap.tsx
+++ b/frontend/src/components/map3d/MiniMap.tsx
@@ -44,11 +44,13 @@ export default function MiniMap({ positionData }: Props) {
         zoom: 12,
       });
 
-      markerRef.current = new mapboxgl.Marker({
-        element: createMarkerElement("/images/droneMarker.svg"),
-      })
+      if(!markerRef.current){
+        markerRef.current = new mapboxgl.Marker({
+          element: createMarkerElement("/images/droneMarker.svg"),
+        })
         .setLngLat([positionData[0].payload.lon, positionData[0].payload.lat])
         .addTo(map);
+      }
     }
   },[positionData])
 

--- a/frontend/src/components/map3d/WeatherWidget.tsx
+++ b/frontend/src/components/map3d/WeatherWidget.tsx
@@ -54,7 +54,7 @@ const WeatherWidget = ({ positionData }: WeatherProps) => {
 
   if (weather.temperature === undefined) {
     return (
-      <div className="relative mx-6 mt-2 flex h-[5vh] w-[30vw] max-w-[17rem] items-center justify-center rounded-[10px] bg-white bg-opacity-60 px-2 text-center text-sm font-bold sm:grid md:grid-cols-[1fr_0.5fr_1fr]">
+      <div className="relative mx-6 mt-2 hidden h-[5vh] w-[30vw] max-w-[17rem] items-center justify-center rounded-[10px] bg-white bg-opacity-60 px-2 text-center text-sm font-bold sm:grid md:grid-cols-[1fr_0.5fr_1fr]">
         Loading...
       </div>
     );

--- a/frontend/src/routes/pages/ChartPage.tsx
+++ b/frontend/src/routes/pages/ChartPage.tsx
@@ -215,7 +215,7 @@ const ChartPage: React.FC = () => {
           altAndSpeedData,
           <AltAndSpeedChart data={altAndSpeedData} />,
         )}
-        {isLoading && <LoadingMessage className="-top-10"/>}
+        {isLoading && <LoadingMessage />}
       </div>
     </div>
   );

--- a/frontend/src/routes/pages/Map3dPage.tsx
+++ b/frontend/src/routes/pages/Map3dPage.tsx
@@ -94,7 +94,7 @@ export default function Map3dPage() {
 
       <CurrentTimeProvider>
         <PhaseContextProvider>
-          <div className="fixed left-4 top-[10rem] z-10">
+          <div className="fixed left-4 top-[11rem] z-10">
             {is2dMap ? (
               <AttitudeWidget
                 headingData={headingData}

--- a/frontend/src/routes/pages/Map3dPage.tsx
+++ b/frontend/src/routes/pages/Map3dPage.tsx
@@ -121,9 +121,9 @@ export default function Map3dPage() {
             />
           </div>
           {is2dMap ? (
-            <Map2D positionData={positionData} stateData={stateData} />
+            <Map2D positionData={positionData} />
           ) : (
-            <CesiumViewer3D positionData={positionData} stateData={stateData} />
+            <CesiumViewer3D positionData={positionData} />
           )}
 
           {!selectedOperationAndDate && 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,10 +2,27 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import cesium from "vite-plugin-cesium";
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), cesium()],
   resolve: {
     alias: [{ find: "@", replacement: "/src" }],
+  },
+  define: {
+    CESIUM_BASE_URL: JSON.stringify("/cesium"),
+  },
+  build: {
+    chunkSizeWarningLimit: 1000, // 번들 크기 경고 제한 증가
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes("node_modules")) {
+            if (id.includes("cesium")) {
+              return "cesium"; // Cesium 별도 번들링
+            }
+            return "vendor"; // 기타 라이브러리 번들
+          }
+        },
+      },
+    },
   },
 });


### PR DESCRIPTION
## 레이아웃
- 로딩 컴포넌트 사이즈 수정: 차트 페이지에서 로딩 컴포넌트가 데이터 헤더까지 덮어서 버튼이 클릭이 안되는 이슈 -> 컴포넌트 사이즈 `h-screen w-screen` 삭제 및 위치 조정
- 위젯 반응형 수정: 위젯별 반응형 적용이 다른부분 수정(자세 위젯 넓이, 날씨위젯 hidden)
- 데이터헤더 반응형 수정: break point 수정 `md` -> `lg`

## 지도
- 드론 기본 회전값 지정: 3d 지도에서의 드론 기본 회전이 정면이 아니어서 경로에 맞춰 수정함(+216deg, 정확히 일치하지 않아서 추후 보완필요)
- 미니맵 마커 중복 오류: 마커가 없는 경우만 마커 추가하도록 수정
- progress bar 컴포넌트 코드 정리: 기능 수정되어 안쓰는 코드 삭제
- 미니맵과 2d 지도 컴포넌트 코드 정리: 중복기능인데 세부적으로 다르게 작성되어있던 코드 통일

## vite.config 옵션 추가
- cesium 별도 번들링하도록 옵션 작성